### PR TITLE
Use /home/ey/bin/gem for chef_gem gem_binary

### DIFF
--- a/cookbooks/chef_gem_fix/libraries/chef_gem.rb
+++ b/cookbooks/chef_gem_fix/libraries/chef_gem.rb
@@ -1,0 +1,8 @@
+class Chef
+  class Resource
+    class ChefGem < Chef::Resource::Package::GemPackage
+      resource_name :chef_gem
+      property :gem_binary, default: "/home/ey/bin/gem"
+    end
+  end
+end

--- a/cookbooks/ey-init/metadata.rb
+++ b/cookbooks/ey-init/metadata.rb
@@ -10,3 +10,4 @@ depends 'ey-core'
 depends 'ey-base'
 
 depends 'docker_custom'
+depends 'chef_gem_fix'

--- a/cookbooks/ey-init/recipes/main.rb
+++ b/cookbooks/ey-init/recipes/main.rb
@@ -12,3 +12,4 @@ include_recipe 'ey-base::post_bootstrap' # common things that we want to install
 
 # Insert any post bootst
 include_recipe 'docker_custom'
+include_recipe 'chef_gem_fix'


### PR DESCRIPTION
This fixes the docker recipe. It will also fix chef_gem for all users.

It results in this warning
```
[2016-07-18T04:13:37+00:00] INFO: Loading cookbook chef_gem_fix's library file: /etc/chef/recipes/cookbooks/chef_gem_fix/libraries/chef_gem.rb
[2016-07-18T04:13:37+00:00] WARN: Default value "/home/ey/bin/gem" is invalid for property gem_binary of resource chef_gem. In Chef 13 this will become an error: Option gem_binary's value /home/ey/bin/gem The chef_gem resource is restricted to the current gem environment, use gem_package to install to other environments.!. at /etc/chef/recipes/cookbooks/chef_gem_fix/libraries/chef_gem.rb:6:in `<class:ChefGem>' at /home/ey/.rvm/rubies/ruby-2.2.3/lib/ruby/gems/2.2.0/gems/chef-12.10.24/lib/chef/event_dispatch/dispatcher.rb:43:in `call'
```