### PR TITLE
Test the docker_custom::default

### DIFF
--- a/cookbooks/docker_custom/spec/default_spec.rb
+++ b/cookbooks/docker_custom/spec/default_spec.rb
@@ -1,0 +1,32 @@
+require 'chefspec'
+
+describe 'docker_custom::default' do
+  let :chef_run do
+    runner.converge described_recipe
+  end
+
+  let :runner do
+    ChefSpec::SoloRunner.new platform: 'gentoo', version: '2.1'
+  end
+
+  context 'in utility instances' do
+    let :runner do
+      ChefSpec::SoloRunner.new(platform: 'gentoo', version: '2.1') do |node|
+        node.default['dna'].tap do |dna|
+          dna['instance_role'] = 'util'
+          dna['name'] = 'docker'
+          
+        end
+      end
+    end 
+    it 'installs docker' do
+      expect(chef_run).to include_recipe 'docker_custom::install'
+    end
+  end
+
+  context 'in other instances' do
+    it 'does nothing' do
+      expect(chef_run).to_not include_recipe 'docker_custom::install'
+    end
+  end
+end


### PR DESCRIPTION
Instructions:

```
gem install chef --version 12.10.24 # the one in resin now
gem install chefspec
gem install docker-api --version 1.28.0 # since chef_gem doesn't actually do
                                        # anything in chefspec
```