### PR TITLE
Parse the docker credential files

### DIFF
--- a/cookbooks/docker_custom/README.md
+++ b/cookbooks/docker_custom/README.md
@@ -3,6 +3,32 @@
 Chef repository and  wrapper cookbook to deploy Docker on a utility instance in
 Engineyard's 2016 stack.
 
+## Docker Hub Credentials
+
+If you need to input your Docker Hub credentials (or any other registry) to pull 
+Docker images, perform the following steps:
+
+
+1.  Login to your Docker host. By default it will be the util instance named
+    `docker`.
+2.  Run `docker login` and input your credentials.
+3.  Check that you have generated your credentials file in
+    `~deploy/.docker/config.json`.
+
+## Third-party Docker Registries
+
+To add additional registries, perform the following steps:
+
+1. Update the `node['docker_custom']['registries']` attribute with the address
+   of the Docker registry you are adding.
+2. Run `docker login <address-of-other-registry>` to insert credentials for your
+   third-party Docker registry.
+
+## Alternative approaches
+
+You can upload your `~/.docker/config.json` file from your workstation to your
+instances instead.
+
 ## LICENSE
 
 Copyright © 2016 Engine Yard, Inc.

--- a/cookbooks/docker_custom/attributes/default.rb
+++ b/cookbooks/docker_custom/attributes/default.rb
@@ -2,3 +2,5 @@ default['docker_custom'] = {
   :docker_instances => ["docker"]
 }
 
+default['docker_custom']['registries'] = %w(https://index.docker.io/v1/)
+

--- a/cookbooks/docker_custom/recipes/default.rb
+++ b/cookbooks/docker_custom/recipes/default.rb
@@ -2,5 +2,7 @@ install_docker = node['dna']['instance_role'] == "util" && node['docker_custom']
 
 if install_docker
   include_recipe "docker_custom::install"
+
+  include_recipe 'docker_custom::registry'
 end
 

--- a/cookbooks/docker_custom/recipes/registry.rb
+++ b/cookbooks/docker_custom/recipes/registry.rb
@@ -1,24 +1,34 @@
 
 credential_file = '/home/deploy/.docker/config.json'
 
-ruby_block 'load dockerhub credentials' do
+registries = node['docker_custom']['registries']
+
+ruby_block 'load docker registry credentials' do
   block do
     require 'json'
     require 'base64'
 
-    registry = resources('docker_registry[https://index.docker.io/v1/]')
-    credentials = JSON.parse(File.read credential_file)['auths']
+    registries.each do |endpoint|
+      registry = resources("docker_registry[#{endpoint}]")
+      credentials = JSON.parse(File.read credential_file)['auths']
 
-    base64 = Base64.decode64 credentials[registry.serveraddress]['auth']
-    username, password = base64.split ':'
+      unless credentials[registry.serveraddress]
+        raise "Cannot find credentials for registry #{registry.serveraddress}"
+      end
 
-    registry.email credentials[registry.serveraddress]['auth']['email']
-    registry.username  username
-    registry.password password
+      base64 = Base64.decode64 credentials[registry.serveraddress]['auth']
+      username, password = base64.split ':'
+
+      registry.email credentials[registry.serveraddress]['auth']['email']
+      registry.username  username
+      registry.password password
+    end
   end
   only_if { File.exists? credential_file }
 end
 
-docker_registry 'https://index.docker.io/v1/' do
-  only_if { File.exists? credential_file }
+registries.each do |endpoint|
+  docker_registry endpoint do
+    only_if { File.exists? credential_file }
+  end
 end

--- a/cookbooks/docker_custom/recipes/registry.rb
+++ b/cookbooks/docker_custom/recipes/registry.rb
@@ -1,0 +1,24 @@
+
+credential_file = '/home/deploy/.docker/config.json'
+
+ruby_block 'load dockerhub credentials' do
+  block do
+    require 'json'
+    require 'base64'
+
+    registry = resources('docker_registry[https://index.docker.io/v1/]')
+    credentials = JSON.parse(File.read credential_file)['auths']
+
+    base64 = Base64.decode64 credentials[registry.serveraddress]['auth']
+    username, password = base64.split ':'
+
+    registry.email credentials[registry.serveraddress]['auth']['email']
+    registry.username  username
+    registry.password password
+  end
+  only_if { File.exists? credential_file }
+end
+
+docker_registry 'https://index.docker.io/v1/' do
+  only_if { File.exists? credential_file }
+end


### PR DESCRIPTION
Similar to the encrypted data bag approach.  But ~/.docker/config.json
is uploaded instead of the encrypted databag and encryption key.